### PR TITLE
fixed the type error

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -110,7 +110,7 @@ async function setupProject() {
 import express from 'express';
 
 const app = express();
-const PORT = import.meta.env.PORT || 3000;
+const PORT = process.env.PORT || 3000;
 
 app.get('/', (req, res) => {
   res.send('Hello, World!');


### PR DESCRIPTION
Updated the Express boilerplate in index.js to use:
const PORT = process.env.PORT || 3000;
This ensures a default port (3000) is used if PORT is not defined.
Now, generated projects will start successfully even if the PORT environment variable is missing.
Testing
Scaffolded a new Express project using the CLI.
Ran npm install and npm run dev in the generated project.
Confirmed the server starts on port 3000 by default and no TypeError occurs.
Additional Notes
No changes were made to other frameworks or unrelated files.
This fix improves the developer experience for users scaffolding new Express projects.
Closes issuse #6 Bug Report